### PR TITLE
Lock nix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "bitflags"
@@ -36,12 +36,6 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
-
-[[package]]
-name = "cc"
-version = "1.0.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 
 [[package]]
 name = "cfg-if"
@@ -233,15 +227,16 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
+ "autocfg",
  "bitflags",
- "cc",
  "cfg-if",
  "libc",
  "memoffset",
+ "pin-utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.107"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "lock_api"
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
  "bitflags",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.107"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "lock_api"
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
  "bitflags",
  "cc",
@@ -375,7 +375,7 @@ dependencies = [
  "futures",
  "log",
  "nix",
- "num-traits 0.2.14",
+ "num-traits 0.1.43",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "lock_api"
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
 dependencies = [
  "bitflags",
  "cc",
@@ -375,7 +375,7 @@ dependencies = [
  "futures",
  "log",
  "nix",
- "num-traits 0.1.43",
+ "num-traits 0.2.14",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,18 +19,18 @@ name = "rs9p"
 crate-type = ["rlib"]
 
 [dependencies]
-log = "^0.4"
-num-traits = "^0.2"
+log = "0.4"
+num-traits = "0.2"
 nix = "0.23.1"
-byteorder = "^1.0"
-bitflags = "^1.0"
-enum_primitive = "*"
-async-trait = "^0.1"
-tokio = { version = "^1.0", features = ["full"] }
-tokio-util = { version = "^0.6", features = ["codec"] }
-tokio-stream = "^0.1"
-bytes = "^1"
-futures = "^0.3"
+byteorder = "1.0"
+bitflags = "1.0"
+enum_primitive = "0.1.1"
+async-trait = "0.1"
+tokio = { version = "1.0", features = ["full"] }
+tokio-util = { version = "0.6", features = ["codec"] }
+tokio-stream = "0.1"
+bytes = "1"
+futures = "0.3"
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 log = "^0.4"
-num-traits = "0.1.43"
+num-traits = "^0.2"
 nix = "0.23.1"
 byteorder = "^1.0"
 bitflags = "^1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["rlib"]
 [dependencies]
 log = "0.4"
 num-traits = "0.2"
-nix = "0.23.1"
+nix = "0.25.0"
 byteorder = "1.0"
 bitflags = "1.0"
 enum_primitive = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 log = "^0.4"
-num-traits = "^0.2"
+num-traits = "0.1.43"
 nix = "0.23.1"
 byteorder = "^1.0"
 bitflags = "^1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["rlib"]
 [dependencies]
 log = "^0.4"
 num-traits = "^0.2"
-nix = "^0"
+nix = "0.23.1"
 byteorder = "^1.0"
 bitflags = "^1.0"
 enum_primitive = "*"

--- a/example/unpfs/Cargo.lock
+++ b/example/unpfs/Cargo.lock
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "bitflags"
@@ -56,12 +56,6 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
-
-[[package]]
-name = "cc"
-version = "1.0.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 
 [[package]]
 name = "cfg-if"
@@ -284,15 +278,16 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
+ "autocfg",
  "bitflags",
- "cc",
  "cfg-if",
  "libc",
  "memoffset",
+ "pin-utils",
 ]
 
 [[package]]

--- a/example/unpfs/Cargo.lock
+++ b/example/unpfs/Cargo.lock
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.107"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "lock_api"
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
  "bitflags",
  "cc",

--- a/example/unpfs/Cargo.lock
+++ b/example/unpfs/Cargo.lock
@@ -443,7 +443,7 @@ dependencies = [
  "futures",
  "log",
  "nix",
- "num-traits 0.2.14",
+ "num-traits 0.1.43",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/example/unpfs/Cargo.lock
+++ b/example/unpfs/Cargo.lock
@@ -443,7 +443,7 @@ dependencies = [
  "futures",
  "log",
  "nix",
- "num-traits 0.1.43",
+ "num-traits 0.2.14",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/example/unpfs/Cargo.toml
+++ b/example/unpfs/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 name = "unpfs"
 
 [dependencies]
-nix = "^0"
+nix = "0.23.1"
 env_logger = "^0"
 filetime = "^0"
 tokio = { version = "^1.0", features = ["full"] }

--- a/example/unpfs/Cargo.toml
+++ b/example/unpfs/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 name = "unpfs"
 
 [dependencies]
-nix = "0.23.1"
+nix = "0.25.0"
 env_logger = "^0"
 filetime = "^0"
 tokio = { version = "^1.0", features = ["full"] }

--- a/example/unpfs/src/main.rs
+++ b/example/unpfs/src/main.rs
@@ -84,14 +84,17 @@ impl Filesystem for Unpfs {
 
         for (i, name) in wnames.iter().enumerate() {
             path.push(name);
-
             let qid = match get_qid(&path).await {
                 Ok(qid) => qid,
-                Err(e) => {
-                    if i == 0 {
-                        return Err(e);
-                    } else {
-                        break;
+                Err(e) => match e.errno() {
+                    // This happens naturally when files are added
+                    nix::errno::Errno::ENOENT => break,
+                    _ => {
+                        if i == 0 {
+                            return Err(e);
+                        } else {
+                            break;
+                        }
                     }
                 }
             };

--- a/src/fcall.rs
+++ b/src/fcall.rs
@@ -9,7 +9,6 @@ use std::os::unix::fs::MetadataExt;
 
 use bitflags::bitflags;
 use enum_primitive::*;
-use nix::sys::statvfs::Statvfs;
 
 /// 9P2000 version string
 pub const P92000: &str = "9P2000";
@@ -321,8 +320,8 @@ pub struct Statfs {
     pub namelen: u32,
 }
 
-impl From<Statvfs> for Statfs {
-    fn from(buf: Statvfs) -> Statfs {
+impl From<nix::sys::statvfs::Statvfs> for Statfs {
+    fn from(buf: nix::sys::statvfs::Statvfs) -> Statfs {
         Statfs {
             typ: 0,
             bsize: buf.block_size() as u32,

--- a/src/fcall.rs
+++ b/src/fcall.rs
@@ -6,10 +6,10 @@
 use std::fs;
 use std::mem::{size_of, size_of_val};
 use std::os::unix::fs::MetadataExt;
-use nix::sys::statvfs::Statvfs;
 
 use bitflags::bitflags;
 use enum_primitive::*;
+use nix::sys::statvfs::Statvfs;
 
 /// 9P2000 version string
 pub const P92000: &str = "9P2000";

--- a/src/fcall.rs
+++ b/src/fcall.rs
@@ -6,6 +6,7 @@
 use std::fs;
 use std::mem::{size_of, size_of_val};
 use std::os::unix::fs::MetadataExt;
+use nix::sys::statvfs::Statvfs;
 
 use bitflags::bitflags;
 use enum_primitive::*;
@@ -320,8 +321,8 @@ pub struct Statfs {
     pub namelen: u32,
 }
 
-impl From<nix::sys::statvfs::Statvfs> for Statfs {
-    fn from(buf: nix::sys::statvfs::Statvfs) -> Statfs {
+impl From<Statvfs> for Statfs {
+    fn from(buf: Statvfs) -> Statfs {
         Statfs {
             typ: 0,
             bsize: buf.block_size() as u32,

--- a/src/fcall.rs
+++ b/src/fcall.rs
@@ -9,6 +9,7 @@ use std::os::unix::fs::MetadataExt;
 
 use bitflags::bitflags;
 use enum_primitive::*;
+use nix::sys::statvfs::Statvfs;
 
 /// 9P2000 version string
 pub const P92000: &str = "9P2000";
@@ -320,8 +321,8 @@ pub struct Statfs {
     pub namelen: u32,
 }
 
-impl From<nix::sys::statvfs::Statvfs> for Statfs {
-    fn from(buf: nix::sys::statvfs::Statvfs) -> Statfs {
+impl From<Statvfs> for Statfs {
+    fn from(buf: Statvfs) -> Statfs {
         Statfs {
             typ: 0,
             bsize: buf.block_size() as u32,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,6 +24,5 @@ pub fn parse_proto(arg: &str) -> Option<(&str, String)> {
         _ => (),
     }
 
-    println!("*******delim is {}", delim);
     Some((proto, addr.to_owned() + delim + port))
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,6 +17,13 @@ macro_rules! res {
 pub fn parse_proto(arg: &str) -> Option<(&str, String)> {
     let mut split = arg.split('!');
     let (proto, addr, port) = (split.next()?, split.next()?, split.next()?);
+    let mut delim = "_";
 
-    Some((proto, addr.to_owned() + ":" + port))
+    match proto == "tcp" {
+        true => delim = ":",
+        _ => (),
+    }
+
+    println!("*******delim is {}", delim);
+    Some((proto, addr.to_owned() + delim + port))
 }


### PR DESCRIPTION
Updates and locks more specific package versions also updates unix protocol to be able to write out the unix socket name in a different pattern to match with vsock capabilities. 